### PR TITLE
Handle KeyError in read_parameter_file

### DIFF
--- a/propka/input.py
+++ b/propka/input.py
@@ -99,7 +99,7 @@ def read_parameter_file(input_file, parameters):
     try:
         ifile = resource_filename(__name__, input_file)
         input_ = open_file_for_reading(ifile)
-    except (IOError, FileNotFoundError, ValueError):
+    except (IOError, FileNotFoundError, ValueError, KeyError):
         input_ = open_file_for_reading(input_file)
     for line in input_:
         parameters.parse_line(line)


### PR DESCRIPTION
Fixes the following error:
```bash
conda create -n propka python=3.8 pytest pandas numpy
conda activate propka
python setup.py install
cd /tmp
propka3 1ubq.pdb
```
Result:
```
KeyError: 'propka/home/thomas/.cache/Python-Eggs/propka-3.2.0-py3.8.egg-tmp/propka/propka.cfg'
```